### PR TITLE
Fix grid printing for unicode files

### DIFF
--- a/grid.rb
+++ b/grid.rb
@@ -125,7 +125,7 @@ class Grid
 
     def to_s
         @grid.map{|line|
-            ' '*(2*@size-1 - line.size) + line.map{|c,d| (d ? '`' : ' ') + (OPERATORS.invert[c]||c[1].chr)}*''
+            ' '*(2*@size-1 - line.size) + line.map{|c,d| (d ? '`' : ' ') + (OPERATORS.invert[c]||c[1].chr(Encoding::UTF_8))}*''
         }*$/
     end
 end


### PR DESCRIPTION
I am trying to print grid, but it doesn't work if the file contains Unicode chars: [try it online](https://tio.run/##S0oszvj/PzmxRMFOIS0zJ5WrqDSpUkE3VUGpKLWwNLMoVV0/v6BEPyO1IjE9P69SP70oM0XduqAoM69EwR3I1ksrys@NLy4BCqQrOAa5u@kVpSamKIHN@v8/MSn5w/wZXQA).
This PR fixes that.